### PR TITLE
Simplify docs and onboarding copy for clearer first-time setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing to Steno. This guide will help you get started with development.
 
+If you only want to run the app as a user, use [QUICKSTART.md](QUICKSTART.md) first. This document is contributor-focused.
+
 ## Prerequisites
 
 Before you begin, ensure you have:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,8 +1,8 @@
 # Steno Quickstart
 
-Fast path to run Steno locally on macOS.
+Fastest path to run Steno locally on macOS.
 
-## 1) Clone and build dependencies
+## 1) Clone and build local transcription dependencies
 
 ```bash
 git clone https://github.com/Ankit-Cherian/steno.git
@@ -15,11 +15,15 @@ cmake -B build && cmake --build build --config Release
 cd ../..
 ```
 
-## 2) Generate project
+Expected result: `whisper.cpp` and the `small.en` model are ready under `vendor/whisper.cpp`.
+
+## 2) Generate the Xcode project
 
 ```bash
 xcodegen generate
 ```
+
+Expected result: `Steno.xcodeproj` is up to date.
 
 ## 3) Run in Xcode
 
@@ -27,17 +31,23 @@ xcodegen generate
 2. Set your Apple Developer Team in Signing & Capabilities.
 3. Run scheme `Steno` (`Cmd+R`).
 4. Grant permissions when prompted:
-   - Microphone
-   - Accessibility
-   - Input Monitoring
+   - Microphone: record your voice
+   - Accessibility: let Steno type or paste into your active app
+   - Input Monitoring: let Steno detect global hotkeys
 
-## Optional: Cloud cleanup
+## Optional: Cloud text cleanup
 
-Set `OPENAI_API_KEY` in your scheme environment if you want cloud transcript cleanup.
-Without it, transcription/cleanup stays local-first.
+Set `OPENAI_API_KEY` in your scheme environment to enable OpenAI text cleanup.
+Without it, Steno stays fully local for transcription and local cleanup.
 
 ## Verify setup quickly
 
 - Press and hold `Option` to record, release to transcribe.
 - Toggle hands-free mode using the configured function key (default `F18`).
-- Confirm insertion works in both a text editor and a terminal target.
+- Confirm text output works in both a text editor and a terminal.
+
+## If something fails
+
+- `xcodegen: command not found`: run `brew install xcodegen`.
+- `cmake: command not found`: run `brew install cmake`.
+- Hotkeys not responding: check Accessibility + Input Monitoring permissions in macOS Settings and relaunch Steno.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,37 @@
 # Steno
 
-Local-first macOS dictation — whisper.cpp transcription with intelligent target-aware insertion
+Private macOS dictation that types where your cursor is.
+
+Steno transcribes locally with `whisper.cpp`, so audio stays on your Mac. You can optionally enable cloud text cleanup for polished output.
 
 [![Swift Tests](https://github.com/Ankit-Cherian/steno/actions/workflows/swift-tests.yml/badge.svg)](https://github.com/Ankit-Cherian/steno/actions/workflows/swift-tests.yml)
 [![Security Audit](https://github.com/Ankit-Cherian/steno/actions/workflows/security-audit.yml/badge.svg)](https://github.com/Ankit-Cherian/steno/actions/workflows/security-audit.yml)
 
-## Features
+## Choose Your Path
 
-- Local audio transcription via whisper.cpp (audio never leaves your Mac)
-- Target-aware text insertion (detects terminals vs editors, adjusts strategy)
-- Optional cloud-powered transcript cleanup (OpenAI, budget-guarded)
-- Global hotkeys: Option hold-to-talk + configurable hands-free toggle
+- **I want to use Steno**: follow [QUICKSTART.md](QUICKSTART.md) or the quick setup below.
+- **I want to contribute**: start with [CONTRIBUTING.md](CONTRIBUTING.md) and the architecture notes below.
+
+## What Steno Does
+
+- Local audio transcription with `whisper.cpp` (audio never leaves your Mac)
+- Smart app-aware paste (target-aware insertion): terminals prefer paste, editors use direct typing or accessibility insertion
+- Optional cloud text cleanup with OpenAI (text-only, budget-guarded)
+- Global hotkeys: Option hold-to-talk and configurable hands-free toggle
 - Menu bar app with status overlay
 - 30-day transcript history with search
-- Personal lexicon, style profiles, and text snippets
-- Full VoiceOver accessibility support
-- Swift 6 strict concurrency throughout
-
-## Architecture
-
-Steno uses a two-layer design:
-
-- **`StenoKit/`** — Pure Swift package with all business logic, protocols, models, services. No UI code.
-- **`Steno/`** — SwiftUI app target with views, `DictationController` orchestrator, settings persistence
-
-Key patterns: protocol-first dependency injection, actor isolation, no singletons, Sendable value types
+- Personal lexicon, style profiles, and snippets
+- VoiceOver accessibility support
 
 ## Requirements
 
 - macOS 13.0+
 - Xcode 26+ (Swift 6.2+)
 - XcodeGen (`brew install xcodegen`)
-- whisper.cpp (built locally)
+- whisper.cpp built locally
+- CMake (`brew install cmake`)
 
-## Getting Started
+## Quick Setup
 
 1. Clone the repository:
    ```bash
@@ -47,12 +45,14 @@ Key patterns: protocol-first dependency injection, actor isolation, no singleton
    cd vendor/whisper.cpp
    git checkout v1.8.3
    cmake -B build && cmake --build build --config Release
+   cd ../..
    ```
 
 3. Download a transcription model:
    ```bash
    cd vendor/whisper.cpp
    ./models/download-ggml-model.sh small.en
+   cd ../..
    ```
 
 4. Generate the Xcode project:
@@ -60,29 +60,44 @@ Key patterns: protocol-first dependency injection, actor isolation, no singleton
    xcodegen generate
    ```
 
-5. Open `Steno.xcodeproj` in Xcode and set your own Apple Developer Team in Signing & Capabilities (the repo intentionally does not hardcode a team ID).
+5. Open `Steno.xcodeproj` in Xcode and set your Apple Developer Team in Signing & Capabilities.
 
 6. Build and run (Cmd+R).
 
 7. Grant required permissions when prompted:
-   - Microphone (for audio recording)
-   - Accessibility (for global hotkeys and direct text insertion)
-   - Input Monitoring (for hotkey interception)
+   - Microphone: record your voice
+   - Accessibility: let Steno type or paste into the active app
+   - Input Monitoring: let Steno detect global hotkeys
 
 ## Usage
 
-- **Option Hold-to-Talk**: Hold Option key to record, release to transcribe and insert
-- **Hands-Free Toggle**: Press configured function key (default F18) to start/stop recording
+- **Option Hold-to-Talk**: hold Option to record, release to transcribe and insert
+- **Hands-Free Toggle**: press the configured function key (default `F18`) to start/stop recording
 - **Menu Bar**: Click icon to show app window, right-click for quick actions
 - **Recording Modes**: Press-to-talk (immediate recording) or hands-free (toggle on/off)
-- **Insertion Strategies**: Target-aware routing — terminals get clipboard+paste, editors get direct typing or accessibility API
+- **Text Output**: app-aware routing picks the safest insertion method for your current app
 
-## Testing
+## Verify Setup
+
+- Hold `Option` to record and release to transcribe.
+- Use the hands-free toggle key (default `F18`).
+- Confirm insertion works in both a text editor and a terminal.
+
+## Architecture (Contributor View)
+
+Steno uses a two-layer design:
+
+- **`StenoKit/`**: pure Swift package with business logic, protocols, models, and services (no UI)
+- **`Steno/`**: SwiftUI app target with views, `DictationController` orchestration, and settings persistence
+
+Key patterns: protocol-first dependency injection, actor isolation, no singletons, `Sendable` value types.
+
+## Testing (Contributor View)
 
 Run the core package tests from the repository root:
 
 ```bash
-cd StenoKit && \
+cd StenoKit
 CLANG_MODULE_CACHE_PATH=/tmp/steno-clang-cache \
 SWIFT_MODULECACHE_PATH=/tmp/steno-swift-cache \
 swift test
@@ -91,7 +106,7 @@ swift test
 Run a single test by function name:
 
 ```bash
-cd StenoKit && \
+cd StenoKit
 CLANG_MODULE_CACHE_PATH=/tmp/steno-clang-cache \
 SWIFT_MODULECACHE_PATH=/tmp/steno-swift-cache \
 swift test --filter budgetGuardDegradedMode
@@ -101,8 +116,8 @@ swift test --filter budgetGuardDegradedMode
 
 - macOS only (no Windows/Linux desktop target yet)
 - Setup currently expects local whisper.cpp build and model download
-- Full end-to-end behavior depends on user-granted macOS permissions (Microphone, Accessibility, Input Monitoring)
-- Cloud cleanup is optional and requires user-provided API key configuration
+- Full end-to-end behavior depends on user-granted macOS permissions
+- Cloud cleanup is optional and requires your own API key
 
 ## Contributing
 

--- a/Steno/InsertionSettingsSection.swift
+++ b/Steno/InsertionSettingsSection.swift
@@ -5,8 +5,8 @@ struct InsertionSettingsSection: View {
     @EnvironmentObject private var controller: DictationController
 
     var body: some View {
-        settingsCard("Insertion") {
-            Text("Order (drag to reorder). Clipboard fallback is always kept.")
+        settingsCard("Text Output (Insertion)") {
+            Text("Choose how Steno inserts text. Drag to set priority. Backup paste via clipboard is always kept.")
                 .font(StenoDesign.caption())
                 .foregroundStyle(StenoDesign.textSecondary)
 
@@ -27,21 +27,21 @@ struct InsertionSettingsSection: View {
 
             HStack {
                 Toggle(
-                    "Direct typing",
+                    "Type directly",
                     isOn: Binding(
                         get: { controller.preferences.insertion.orderedMethods.contains(.direct) },
                         set: { setInsertionMethod(.direct, enabled: $0) }
                     )
                 )
                 Toggle(
-                    "Accessibility",
+                    "Accessibility insert",
                     isOn: Binding(
                         get: { controller.preferences.insertion.orderedMethods.contains(.accessibility) },
                         set: { setInsertionMethod(.accessibility, enabled: $0) }
                     )
                 )
                 Toggle(
-                    "Clipboard fallback",
+                    "Backup paste via clipboard",
                     isOn: Binding(
                         get: { controller.preferences.insertion.orderedMethods.contains(.clipboardPaste) },
                         set: { setInsertionMethod(.clipboardPaste, enabled: $0) }
@@ -71,9 +71,9 @@ struct InsertionSettingsSection: View {
 
     private func label(for method: InsertionMethod) -> String {
         switch method {
-        case .direct: return "Direct typing"
-        case .accessibility: return "Accessibility"
-        case .clipboardPaste: return "Clipboard fallback"
+        case .direct: return "Type directly"
+        case .accessibility: return "Accessibility insert"
+        case .clipboardPaste: return "Backup paste via clipboard"
         case .none: return "None"
         }
     }

--- a/Steno/MediaSettingsSection.swift
+++ b/Steno/MediaSettingsSection.swift
@@ -5,11 +5,11 @@ struct MediaSettingsSection: View {
 
     var body: some View {
         settingsCard("Media") {
-            Toggle("Pause media during hold-to-talk (Option)",
+            Toggle("Pause music/video during hold-to-talk (Option)",
                    isOn: $controller.preferences.media.pauseDuringPressToTalk)
-            Toggle("Pause media during hands-free",
+            Toggle("Pause music/video during hands-free dictation",
                    isOn: $controller.preferences.media.pauseDuringHandsFree)
-            Text("Best-effort system play/pause control around recording sessions.")
+            Text("Steno only sends play/pause when playback is clearly active.")
                 .font(StenoDesign.caption())
                 .foregroundStyle(StenoDesign.textSecondary)
         }

--- a/Steno/OnboardingView.swift
+++ b/Steno/OnboardingView.swift
@@ -105,15 +105,15 @@ struct OnboardingView: View {
                     .foregroundStyle(StenoDesign.textPrimary)
                     .accessibilityAddTraits(.isHeader)
 
-                Text("Privacy-first dictation for macOS")
+                Text("Private dictation that types into your active app")
                     .font(StenoDesign.subheadline())
                     .foregroundStyle(StenoDesign.textSecondary)
             }
 
             VStack(alignment: .leading, spacing: StenoDesign.md) {
-                featureRow(icon: "lock.shield", title: "Local-first", detail: "Audio stays on your Mac. Only text optionally goes to the cloud.")
+                featureRow(icon: "lock.shield", title: "Private by default", detail: "Audio stays on your Mac. Only transcript text can go to cloud cleanup if you opt in.")
                 featureRow(icon: "bolt", title: "Fast", detail: "Whisper.cpp transcribes locally in seconds.")
-                featureRow(icon: "text.cursor", title: "Universal", detail: "Inserts text directly into any app.")
+                featureRow(icon: "text.cursor", title: "Works across apps", detail: "Types or pastes into editors, terminals, and most text fields.")
             }
             .cardStyle()
 
@@ -168,7 +168,7 @@ struct OnboardingView: View {
 
                 PermissionStatusCard(
                     title: "Accessibility",
-                    description: "Enables direct text insertion into apps.",
+                    description: "Lets Steno type or paste into the app you're using.",
                     status: controller.accessibilityPermissionStatus,
                     onRequest: { controller.requestAccessibilityPermission() },
                     onOpenSettings: { controller.openAccessibilitySettings() }
@@ -176,7 +176,7 @@ struct OnboardingView: View {
 
                 PermissionStatusCard(
                     title: "Input Monitoring",
-                    description: "Allows global hotkey for hands-free dictation.",
+                    description: "Lets Steno detect global hotkeys while other apps are focused.",
                     status: controller.inputMonitoringPermissionStatus,
                     onRequest: { controller.requestInputMonitoringPermission() },
                     onOpenSettings: { controller.openInputMonitoringSettings() }
@@ -203,12 +203,12 @@ struct OnboardingView: View {
             Spacer()
 
             VStack(spacing: StenoDesign.sm) {
-                Text("Whisper Setup")
+                Text("Local Transcription Setup")
                     .font(StenoDesign.heading1())
                     .foregroundStyle(StenoDesign.textPrimary)
                     .accessibilityAddTraits(.isHeader)
 
-                Text("Verify the paths to your local whisper-cli and model file.")
+                Text("Confirm the paths to your local whisper-cli binary and model file.")
                     .font(StenoDesign.subheadline())
                     .foregroundStyle(StenoDesign.textSecondary)
             }
@@ -218,7 +218,7 @@ struct OnboardingView: View {
                     Text("whisper-cli path")
                         .font(StenoDesign.bodyEmphasis())
                         .foregroundStyle(StenoDesign.textPrimary)
-                    TextField("Path to whisper-cli", text: $whisperCLIPath)
+                    TextField("Path to whisper-cli binary", text: $whisperCLIPath)
                         .textFieldStyle(.roundedBorder)
                     pathValidationLabel(valid: whisperCLIPathValid)
                 }
@@ -269,7 +269,7 @@ struct OnboardingView: View {
                     .foregroundStyle(StenoDesign.textPrimary)
                     .accessibilityAddTraits(.isHeader)
 
-                Text("Cloud cleanup is optional. Steno works great without it using local-only processing.")
+                Text("Cloud text cleanup is optional. Steno works fully in local-only mode without it.")
                     .font(StenoDesign.subheadline())
                     .foregroundStyle(StenoDesign.textSecondary)
                     .multilineTextAlignment(.center)
@@ -284,7 +284,7 @@ struct OnboardingView: View {
                         .textFieldStyle(.roundedBorder)
                 }
 
-                Text("If provided, transcript text (not audio) is sent to OpenAI for cleanup. You can always change this in Settings.")
+                Text("If provided, Steno sends transcript text (never audio) to OpenAI for cleanup. You can change this later in Settings.")
                     .font(StenoDesign.caption())
                     .foregroundStyle(StenoDesign.textSecondary)
             }

--- a/Steno/PermissionsSettingsSection.swift
+++ b/Steno/PermissionsSettingsSection.swift
@@ -15,7 +15,7 @@ struct PermissionsSettingsSection: View {
 
             PermissionStatusCard(
                 title: "Accessibility",
-                description: "Enables direct text insertion into apps.",
+                description: "Lets Steno type or paste into the app you're using.",
                 status: controller.accessibilityPermissionStatus,
                 onRequest: { controller.requestAccessibilityPermission() },
                 onOpenSettings: { controller.openAccessibilitySettings() }
@@ -23,7 +23,7 @@ struct PermissionsSettingsSection: View {
 
             PermissionStatusCard(
                 title: "Input Monitoring",
-                description: "Allows global hotkey for hands-free dictation.",
+                description: "Lets Steno detect global hotkeys while other apps are focused.",
                 status: controller.inputMonitoringPermissionStatus,
                 onRequest: { controller.requestInputMonitoringPermission() },
                 onOpenSettings: { controller.openInputMonitoringSettings() }

--- a/Steno/SettingsView.swift
+++ b/Steno/SettingsView.swift
@@ -46,7 +46,7 @@ struct SettingsView: View {
                         }
                         Button("Cancel", role: .cancel) {}
                     } message: {
-                        Text("This will remove your saved OpenAI API key. Cloud cleanup will fall back to local mode.")
+                        Text("This removes your saved OpenAI API key. Steno will return to local-only cleanup.")
                     }
 
                     Spacer()


### PR DESCRIPTION
## Summary

This PR makes Steno easier to understand for first-time users while keeping contributor-level technical detail intact.

## What changed

- Reworked `README.md` with:
  - a plain-language app description at the top
  - clear "use vs contribute" paths
  - simplified setup, permissions, and usage wording
  - contributor architecture/testing details moved lower in the page
- Updated `QUICKSTART.md` with:
  - clearer step names
  - expected-result callouts
  - a short troubleshooting section for common setup failures
- Updated `CONTRIBUTING.md` intro to clearly mark it as contributor-focused
- Aligned in-app copy with docs terminology in:
  - onboarding text
  - insertion settings labels
  - permissions descriptions
  - media pause wording
  - API key clear-confirmation message

## Why

Current wording is technically accurate but harder to scan for non-technical users.  
This pass keeps technical precision but leads with plain language and clearer setup guidance.

## Validation

- `swift test --package-path StenoKit`
- `xcodebuild build -project Steno.xcodeproj -scheme Steno -destination 'platform=macOS'`

## Notes

- No behavior changes; copy/docs only.
- No signing/project-configuration changes.
