### PR TITLE
fix(stenokit): final follow-up for phantom media-start race condition

### DIFF
--- a/StenoKit/Sources/StenoKit/Services/MacMediaInterruptionService.swift
+++ b/StenoKit/Sources/StenoKit/Services/MacMediaInterruptionService.swift
@@ -140,10 +140,10 @@ final class MultiSignalMediaPlaybackStateDetector: MediaPlaybackStateDetector {
             result = .playing
         } else if hasStrongPositive && hasStrongNegative {
             result = .unknown
-        } else if hasWeakPositive {
-            result = .likelyPlaying
         } else if hasStrongNegative {
             result = .notPlaying
+        } else if hasWeakPositive {
+            result = .likelyPlaying
         } else {
             result = .unknown
         }

--- a/StenoKit/Tests/StenoKitTests/MacMediaInterruptionServiceTests.swift
+++ b/StenoKit/Tests/StenoKitTests/MacMediaInterruptionServiceTests.swift
@@ -214,8 +214,8 @@ func detectorReturnsLikelyPlayingForWeakPositives() async {
 }
 
 @MainActor
-@Test("Detector prefers weak positive over ambiguous strong-negative probes")
-func detectorPrefersWeakPositiveOverAmbiguousStrongNegativeProbes() async {
+@Test("Detector prefers strong-negative evidence over weak positives")
+func detectorPrefersStrongNegativeOverWeakPositiveProbes() async {
     let bridge = FakeMediaRemoteBridge()
     bridge.nowPlayingApplicationIsPlayingValue = true
     bridge.nowPlayingPlaybackRateValue = 0
@@ -223,7 +223,23 @@ func detectorPrefersWeakPositiveOverAmbiguousStrongNegativeProbes() async {
     let detector = MultiSignalMediaPlaybackStateDetector(bridge: bridge)
     let result = await detector.detect()
 
-    #expect(result == .likelyPlaying)
+    #expect(result == .notPlaying)
+}
+
+@MainActor
+@Test("Detector returns not playing for any=true with advancing=false and no strong positive")
+func detectorReturnsNotPlayingForAnyTrueAndAdvancingFalseWithoutStrongPositive() async {
+    let bridge = FakeMediaRemoteBridge()
+    bridge.anyApplicationIsPlayingValue = true
+    bridge.nowPlayingApplicationIsPlayingValue = false
+    bridge.nowPlayingPlaybackStateValue = 2
+    bridge.playbackStateIsAdvancingValue = false
+    bridge.nowPlayingPlaybackRateValue = nil
+
+    let detector = MultiSignalMediaPlaybackStateDetector(bridge: bridge)
+    let result = await detector.detect()
+
+    #expect(result == .notPlaying)
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

This is the final follow-up for the phantom media-start bug on dictation start.

Earlier guardrails covered unknown/no-evidence cases. This PR closes the remaining path: weak-positive playback probes overriding strong-negative evidence, which could still trigger a synthetic play/pause and open Music.

What changed:
- Reordered playback detection precedence so strong-negative evidence resolves to `notPlaying` before weak positives are considered.
- Kept weak positives mapped to `likelyPlaying` only when no strong positive/negative evidence exists.
- Added regression coverage for the exact mixed-signal pattern seen in live logs (`any=true`, `stateAdvancing=false`, no strong positive).

Validation run:
- `swift test --package-path StenoKit`
- `xcodebuild build -project Steno.xcodeproj -scheme Steno -destination 'platform=macOS'`

## Checklist

- [x] `swift test` passes in `StenoKit`
- [x] No force unwraps (`as!` or `try!`) in production code
- [x] UI uses `StenoDesign` tokens (no hardcoded fonts, shadows, or spacing) (N/A: no UI changes)
- [x] Interactive elements have VoiceOver labels (N/A: no UI changes)
- [x] Animations check `accessibilityReduceMotion` (N/A: no animation changes)
- [x] No hardcoded credentials, keys, or private endpoints
- [x] Security-sensitive behavior changes include tests and documentation updates (N/A: not security-sensitive; tests added)
