### PR TITLE
fix: prepare stability patch release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-03-03
+
+### Changed
+- Hardened hotkey lifecycle and shutdown behavior to avoid late callback execution during stop/quit, including idempotent teardown and eager overlay window warm-up.
+- Updated synthetic event routing so insertion and paste remain configurable through `STENO_SYNTH_EVENT_TAP`, while media keys use a dedicated tap resolver with HID as the default.
+- Improved subprocess execution reliability by streaming pipe output during process lifetime, adding cancellation escalation safeguards, and caching whisper process environment setup at engine initialization.
+- Optimized local cleanup and replacement paths by precompiling reusable regexes, caching lexicon/snippet regexes with cache invalidation on mutation, and preserving longest-first lexicon ordering as an explicit invariant.
+- Reduced history persistence overhead by removing pretty-printed JSON output formatting.
+
+### Fixed
+- Restored reliable media pause/resume behavior during dictation by routing media key posting through a dedicated HID-default tap path.
+- Prevented event-tap re-enable thrash with debounce handling after timeout/user-input tap disable events.
+- Added defensive teardown behavior for overlay timers and hotkey monitor resources during object deinitialization.
+- Prevented potential deadlocks and cancellation stalls in process execution paths when child processes ignore graceful termination.
+
+### Tests
+- Added media key tap routing regression coverage for default, override, and invalid environment values.
+- Hardened cancellation regression coverage to verify bounded completion when subprocesses ignore `SIGTERM`.
+
 ## [0.1.6] - 2026-03-03
 
 ### Added

--- a/Steno/DictationController.swift
+++ b/Steno/DictationController.swift
@@ -42,6 +42,7 @@ final class DictationController: ObservableObject {
     private var pendingRuntimeRebuild = false
     private let menuBar = MenuBarController()
     private var recordingTimer: Timer?
+    private var terminationObserver: Any?
 
     init(
         hotkey: MacHotkeyMonitor = MacHotkeyMonitor(),
@@ -85,9 +86,36 @@ final class DictationController: ObservableObject {
         hotkey.start()
         menuBar.setup(controller: self)
 
+        terminationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.teardown()
+        }
+
         Task {
             await bootstrap()
         }
+    }
+
+    /// Idempotent shutdown: stops hotkeys, cancels in-flight work, releases media,
+    /// hides the overlay, and invalidates timers. Triggered by willTerminateNotification.
+    func teardown() {
+        if let observer = terminationObserver {
+            NotificationCenter.default.removeObserver(observer)
+            terminationObserver = nil
+        }
+        hotkey.stop()
+        overlay.hide()
+        activeStartTask?.cancel()
+        activeStartTask = nil
+        if let token = activeMediaToken {
+            mediaInterruption.endInterruption(token: token)
+            activeMediaToken = nil
+        }
+        recordingTimer?.invalidate()
+        recordingTimer = nil
     }
 
     var menuBarIconName: String {
@@ -108,6 +136,7 @@ final class DictationController: ObservableObject {
         validateWhisperPaths()
         await rebuildRuntime()
         await refreshHistory()
+        overlay.prepareWindow()
         hasBootstrapped = true
     }
 

--- a/StenoKit/Sources/StenoKit/Models/Profiles.swift
+++ b/StenoKit/Sources/StenoKit/Models/Profiles.swift
@@ -69,8 +69,10 @@ public struct LexiconEntry: Sendable, Codable, Equatable {
 public struct PersonalLexicon: Sendable, Codable, Equatable {
     public var entries: [LexiconEntry]
 
+    /// Entries are sorted longest-term-first so longer multi-word phrases
+    /// match before shorter substrings during lexicon application.
     public init(entries: [LexiconEntry] = []) {
-        self.entries = entries
+        self.entries = entries.sorted { $0.term.count > $1.term.count }
     }
 }
 

--- a/StenoKit/Sources/StenoKit/Services/HistoryStore.swift
+++ b/StenoKit/Sources/StenoKit/Services/HistoryStore.swift
@@ -113,7 +113,7 @@ public actor HistoryStore: HistoryStoreProtocol {
 
     private func persist() throws {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted]
+        encoder.outputFormatting = []
         encoder.dateEncodingStrategy = .iso8601
 
         do {

--- a/StenoKit/Sources/StenoKit/Services/MacHotkeyMonitor.swift
+++ b/StenoKit/Sources/StenoKit/Services/MacHotkeyMonitor.swift
@@ -8,6 +8,9 @@ private final class TapContext: @unchecked Sendable {
     var keyCode: UInt16?
     var onToggle: (() -> Void)?
     var machPort: CFMachPort?
+    /// Monotonic timestamp of the last tap re-enable, used to debounce rapid
+    /// disable/re-enable cycles that can occur when the system times out the tap.
+    var lastReenableTime: CFAbsoluteTime = 0
 }
 
 @MainActor
@@ -31,6 +34,7 @@ public final class MacHotkeyMonitor: HotkeyService {
     private var globalFlagsMonitor: Any?
     private var localFlagsMonitor: Any?
     private var isOptionHeld = false
+    private var callbackGeneration: UInt64 = 0
 
     private var hasStarted = false
 
@@ -49,12 +53,14 @@ public final class MacHotkeyMonitor: HotkeyService {
 
     public func start() {
         guard !hasStarted else { return }
+        callbackGeneration &+= 1
         hasStarted = true
         installOptionMonitors()
         updateHandsFreeStatus()
     }
 
     public func stop() {
+        callbackGeneration &+= 1
         hasStarted = false
         uninstallEventTap()
         uninstallOptionMonitors()
@@ -98,10 +104,28 @@ public final class MacHotkeyMonitor: HotkeyService {
         }
 
         isOptionHeld = optionIsNowHeld
+        let generation = callbackGeneration
+
+        // Dispatch callbacks async to avoid re-entrancy while the
+        // NSEvent monitor callback is still unwinding.
         if optionIsNowHeld {
-            onPressToTalkStart?()
+            Task { @MainActor [weak self] in
+                guard let self,
+                      self.hasStarted,
+                      self.callbackGeneration == generation else {
+                    return
+                }
+                self.onPressToTalkStart?()
+            }
         } else {
-            onPressToTalkStop?()
+            Task { @MainActor [weak self] in
+                guard let self,
+                      self.hasStarted,
+                      self.callbackGeneration == generation else {
+                    return
+                }
+                self.onPressToTalkStop?()
+            }
         }
     }
 
@@ -168,12 +192,19 @@ public final class MacHotkeyMonitor: HotkeyService {
     /// C-compatible callback for the CGEventTap. Runs on the main thread
     /// (tap is installed on the main run loop). Accesses TapContext via userInfo
     /// to avoid @MainActor isolation issues.
+    /// Minimum interval between tap re-enables to prevent rapid disable/enable cycling.
+    private static let reenableDebounceInterval: CFAbsoluteTime = 0.1
+
     private static let eventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in
-        // Re-enable tap if macOS disabled it due to timeout or user input
+        // Re-enable tap if macOS disabled it due to timeout or user input,
+        // with a debounce to avoid rapid re-enable cycling.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             if let userInfo {
                 let ctx = Unmanaged<TapContext>.fromOpaque(userInfo).takeUnretainedValue()
-                if let machPort = ctx.machPort {
+                let now = CFAbsoluteTimeGetCurrent()
+                if let machPort = ctx.machPort,
+                   now - ctx.lastReenableTime >= reenableDebounceInterval {
+                    ctx.lastReenableTime = now
                     CGEvent.tapEnable(tap: machPort, enable: true)
                 }
             }
@@ -201,6 +232,17 @@ public final class MacHotkeyMonitor: HotkeyService {
         // re-entrancy while the tap callback is still unwinding.
         DispatchQueue.main.async { ctx.onToggle?() }
         return nil // For .defaultTap, nil suppresses delivery to downstream apps.
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            uninstallEventTap()
+            uninstallOptionMonitors()
+            // Clear callback state defensively after uninstall.
+            tapContext.machPort = nil
+            tapContext.onToggle = nil
+            tapContext.keyCode = nil
+        }
     }
 
     // MARK: - Utilities

--- a/StenoKit/Sources/StenoKit/Services/MacInsertionTransports.swift
+++ b/StenoKit/Sources/StenoKit/Services/MacInsertionTransports.swift
@@ -3,6 +3,16 @@ import AppKit
 import ApplicationServices
 import Foundation
 
+/// Preferred tap location for synthetic event posting.
+/// Defaults to `.cgAnnotatedSessionEventTap` (avoids traversing other event taps).
+/// Set `STENO_SYNTH_EVENT_TAP=hid` in the environment to revert to `.cghidEventTap`.
+let stenoSyntheticEventTapLocation: CGEventTapLocation = {
+    if ProcessInfo.processInfo.environment["STENO_SYNTH_EVENT_TAP"]?.lowercased() == "hid" {
+        return .cghidEventTap
+    }
+    return .cgAnnotatedSessionEventTap
+}()
+
 public enum MacInsertionError: Error, LocalizedError {
     case eventSourceUnavailable
     case accessibilityPermissionMissing
@@ -126,8 +136,8 @@ public struct DirectTypingInsertionTransport: InsertionTransport {
             // InsertionService keeps accessibility and clipboard transports as fallbacks.
             keyDown.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: chunk)
             keyUp.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: chunk)
-            keyDown.post(tap: .cghidEventTap)
-            keyUp.post(tap: .cghidEventTap)
+            keyDown.post(tap: stenoSyntheticEventTapLocation)
+            keyUp.post(tap: stenoSyntheticEventTapLocation)
 
             if end < allCodeUnits.count {
                 try await Task.sleep(nanoseconds: 10_000_000) // 10ms between chunks
@@ -328,8 +338,8 @@ public enum MacPasteHelper {
         else { return false }
         keyDown.flags = .maskCommand
         keyUp.flags = .maskCommand
-        keyDown.post(tap: .cghidEventTap)
-        keyUp.post(tap: .cghidEventTap)
+        keyDown.post(tap: stenoSyntheticEventTapLocation)
+        keyUp.post(tap: stenoSyntheticEventTapLocation)
         return true
     }
 }

--- a/StenoKit/Sources/StenoKit/Services/MacMediaInterruptionService.swift
+++ b/StenoKit/Sources/StenoKit/Services/MacMediaInterruptionService.swift
@@ -2,6 +2,17 @@
 import AppKit
 import IOKit.hidsystem
 
+internal func stenoMediaKeyTapLocation(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> CGEventTapLocation {
+    switch environment["STENO_MEDIA_KEY_TAP"]?.lowercased() {
+    case "annotated":
+        return .cgAnnotatedSessionEventTap
+    default:
+        return .cghidEventTap
+    }
+}
+
 @MainActor
 public final class MacMediaInterruptionService: MediaInterruptionService {
     private static let logger = StenoKitDiagnostics.logger
@@ -435,10 +446,11 @@ final class MediaRemoteBridge: MediaRemoteBridging {
             setWantsNowPlayingNotifications?(false)
             StenoKitDiagnostics.logger.debug("MediaRemote bridge deinit forced unregister cleanup.")
         }
-        // Ensure callbackQueue has drained before unloading the framework image.
-        callbackQueue.sync {}
-        if let handle {
-            dlclose(handle)
+        // Defer dlclose to after the serial callbackQueue drains, avoiding
+        // a sync-on-self deadlock if deinit runs on the callbackQueue thread.
+        let handle = self.handle
+        callbackQueue.async {
+            if let handle { dlclose(handle) }
         }
     }
 
@@ -580,6 +592,8 @@ private enum SystemMediaKeySender {
     private static func postSystemDefinedMediaEvent(key: Int32, isKeyDown: Bool) -> Bool {
         // Undocumented system media event encoding used by NSEvent.systemDefined.
         // keyState 0xA = down, 0xB = up; modifierFlags 0xA00 marks media-key context.
+        // Media keys intentionally use a dedicated tap policy for compatibility,
+        // separate from insertion event posting.
         let keyState = isKeyDown ? 0xA : 0xB
         let data1 = Int((key << 16) | (Int32(keyState) << 8))
 
@@ -597,7 +611,7 @@ private enum SystemMediaKeySender {
             return false
         }
 
-        event.cgEvent?.post(tap: .cghidEventTap)
+        event.cgEvent?.post(tap: stenoMediaKeyTapLocation())
         return true
     }
 }

--- a/StenoKit/Sources/StenoKit/Services/MacOverlayPresenter.swift
+++ b/StenoKit/Sources/StenoKit/Services/MacOverlayPresenter.swift
@@ -31,7 +31,18 @@ public final class MacOverlayPresenter: NSObject, OverlayPresenter {
     }
 
     deinit {
-        NSWorkspace.shared.notificationCenter.removeObserver(self)
+        MainActor.assumeIsolated {
+            timer?.invalidate()
+            timer = nil
+            pulseTimer?.invalidate()
+            pulseTimer = nil
+            NSWorkspace.shared.notificationCenter.removeObserver(self)
+        }
+    }
+
+    /// Pre-create the overlay window so the first `show` has no lazy-init stutter.
+    public func prepareWindow() {
+        ensureWindow()
     }
 
     public func show(state: OverlayState) {

--- a/StenoKit/Sources/StenoKit/Services/PersonalLexiconService.swift
+++ b/StenoKit/Sources/StenoKit/Services/PersonalLexiconService.swift
@@ -12,9 +12,11 @@ public struct LexiconApplicationResult: Sendable, Equatable {
 
 public actor PersonalLexiconService {
     private var entries: [LexiconEntry]
+    /// Compiled regexes keyed by lowercased term. Invalidated on mutation.
+    private var regexCache: [String: NSRegularExpression] = [:]
 
     public init(entries: [LexiconEntry] = []) {
-        self.entries = entries
+        self.entries = entries.sorted { $0.term.count > $1.term.count }
     }
 
     public func upsert(term: String, preferred: String, scope: Scope) {
@@ -24,16 +26,19 @@ public actor PersonalLexiconService {
             $0.term.caseInsensitiveCompare(term) == .orderedSame && $0.scope == scope
         }) {
             entries[index] = LexiconEntry(term: term, preferred: preferred, scope: scope)
-            return
+        } else {
+            entries.append(LexiconEntry(term: term, preferred: preferred, scope: scope))
         }
 
-        entries.append(LexiconEntry(term: term, preferred: preferred, scope: scope))
+        entries.sort { $0.term.count > $1.term.count }
+        regexCache.removeAll()
     }
 
     public func remove(term: String, scope: Scope) {
         entries.removeAll {
             $0.term.caseInsensitiveCompare(term) == .orderedSame && $0.scope == scope
         }
+        regexCache.removeAll()
     }
 
     public func snapshot() -> PersonalLexicon {
@@ -53,8 +58,8 @@ public actor PersonalLexiconService {
             return LexiconApplicationResult(text: text, edits: [])
         }
 
+        // Entries are already sorted longest-first by the actor invariant.
         let applicable = filteredEntries(for: appContext)
-            .sorted { $0.term.count > $1.term.count }
 
         var updatedText = text
         var edits: [TranscriptEdit] = []
@@ -62,8 +67,7 @@ public actor PersonalLexiconService {
         for entry in applicable {
             let replacement = replaceWholeWord(
                 in: updatedText,
-                pattern: entry.term,
-                replacement: entry.preferred
+                entry: entry
             )
             if replacement.replacements > 0 {
                 updatedText = replacement.text
@@ -93,14 +97,20 @@ public actor PersonalLexiconService {
 
     private func replaceWholeWord(
         in text: String,
-        pattern: String,
-        replacement: String
+        entry: LexiconEntry
     ) -> (text: String, replacements: Int) {
-        let escaped = NSRegularExpression.escapedPattern(for: pattern)
-        let regexPattern = "\\b\(escaped)\\b"
-
-        guard let regex = try? NSRegularExpression(pattern: regexPattern, options: [.caseInsensitive]) else {
-            return (text, 0)
+        let cacheKey = entry.term.lowercased()
+        let regex: NSRegularExpression
+        if let cached = regexCache[cacheKey] {
+            regex = cached
+        } else {
+            let escaped = NSRegularExpression.escapedPattern(for: entry.term)
+            let regexPattern = "\\b\(escaped)\\b"
+            guard let compiled = try? NSRegularExpression(pattern: regexPattern, options: [.caseInsensitive]) else {
+                return (text, 0)
+            }
+            regexCache[cacheKey] = compiled
+            regex = compiled
         }
 
         let nsRange = NSRange(text.startIndex..., in: text)
@@ -109,7 +119,8 @@ public actor PersonalLexiconService {
             return (text, 0)
         }
 
-        let replaced = regex.stringByReplacingMatches(in: text, range: nsRange, withTemplate: replacement)
+        let safeReplacement = NSRegularExpression.escapedTemplate(for: entry.preferred)
+        let replaced = regex.stringByReplacingMatches(in: text, range: nsRange, withTemplate: safeReplacement)
         return (replaced, matchCount)
     }
 }

--- a/StenoKit/Sources/StenoKit/Services/RuleBasedCleanupEngine.swift
+++ b/StenoKit/Sources/StenoKit/Services/RuleBasedCleanupEngine.swift
@@ -60,6 +60,38 @@ public struct RuleBasedCleanupEngine: CleanupEngine, Sendable {
         )
     }
 
+    // MARK: - Precompiled Regexes
+
+    private static let fillerRegexes: [String: NSRegularExpression] = {
+        let fillers = ["um", "uh", "you know", "i mean", "basically", "sort of", "kind of"]
+        var dict: [String: NSRegularExpression] = [:]
+        for filler in fillers {
+            let escaped = NSRegularExpression.escapedPattern(for: filler)
+            let pattern = "(?i)(?:\\s|^)\(escaped)(?=\\s|[,.!?]|$)"
+            if let regex = try? NSRegularExpression(pattern: pattern) {
+                dict[filler] = regex
+            }
+        }
+        return dict
+    }()
+
+    private static let likePatterns: [(regex: NSRegularExpression, replacement: String)] = {
+        let specs: [(pattern: String, replacement: String)] = [
+            ("(?i)(^|[.!?]\\s+)like,\\s+", "$1"),
+            ("(?i),\\s*like,\\s*", ", ")
+        ]
+        return specs.compactMap { spec in
+            guard let regex = try? NSRegularExpression(pattern: spec.pattern) else { return nil }
+            return (regex, spec.replacement)
+        }
+    }()
+
+    private static let whitespaceRegex: NSRegularExpression = {
+        try! NSRegularExpression(pattern: "\\s+")
+    }()
+
+    // MARK: - Filler Removal
+
     private func removeFillers(from text: String, policy: FillerPolicy) -> (text: String, removed: [String], edits: [TranscriptEdit]) {
         guard policy != .minimal else {
             return (text, [], [])
@@ -74,9 +106,7 @@ public struct RuleBasedCleanupEngine: CleanupEngine, Sendable {
         var edits: [TranscriptEdit] = []
 
         for filler in directFillers {
-            let escaped = NSRegularExpression.escapedPattern(for: filler)
-            let pattern = "(?i)(?:\\s|^)\(escaped)(?=\\s|[,.!?]|$)"
-            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            guard let regex = Self.fillerRegexes[filler] else { continue }
 
             let range = NSRange(updated.startIndex..., in: updated)
             let count = regex.numberOfMatches(in: updated, range: range)
@@ -102,19 +132,11 @@ public struct RuleBasedCleanupEngine: CleanupEngine, Sendable {
         var updated = text
         var removedCount = 0
 
-        let patterns: [(pattern: String, replacement: String)] = [
-            // Sentence-initial discourse marker: "Like, ..."
-            ("(?i)(^|[.!?]\\s+)like,\\s+", "$1"),
-            // Parenthetical discourse marker: ", like, ..."
-            ("(?i),\\s*like,\\s*", ", ")
-        ]
-
-        for item in patterns {
-            guard let regex = try? NSRegularExpression(pattern: item.pattern) else { continue }
+        for item in Self.likePatterns {
             let range = NSRange(updated.startIndex..., in: updated)
-            let count = regex.numberOfMatches(in: updated, range: range)
+            let count = item.regex.numberOfMatches(in: updated, range: range)
             if count > 0 {
-                updated = regex.stringByReplacingMatches(in: updated, range: range, withTemplate: item.replacement)
+                updated = item.regex.stringByReplacingMatches(in: updated, range: range, withTemplate: item.replacement)
                 removedCount += count
             }
         }
@@ -122,24 +144,30 @@ public struct RuleBasedCleanupEngine: CleanupEngine, Sendable {
         return (updated, removedCount)
     }
 
+    // MARK: - Lexicon
+
     private func applyLexicon(text: String, lexicon: PersonalLexicon) -> (text: String, edits: [TranscriptEdit]) {
         var updated = text
         var edits: [TranscriptEdit] = []
 
-        for entry in lexicon.entries.sorted(by: { $0.term.count > $1.term.count }) {
+        // Lexicon entries are already sorted longest-first by the PersonalLexicon invariant.
+        for entry in lexicon.entries {
             let escaped = NSRegularExpression.escapedPattern(for: entry.term)
             let pattern = "\\b\(escaped)\\b"
             guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { continue }
             let range = NSRange(updated.startIndex..., in: updated)
             let count = regex.numberOfMatches(in: updated, range: range)
             if count > 0 {
-                updated = regex.stringByReplacingMatches(in: updated, range: range, withTemplate: entry.preferred)
+                let safeReplacement = NSRegularExpression.escapedTemplate(for: entry.preferred)
+                updated = regex.stringByReplacingMatches(in: updated, range: range, withTemplate: safeReplacement)
                 edits.append(TranscriptEdit(kind: .lexiconCorrection, from: entry.term, to: entry.preferred))
             }
         }
 
         return (updated, edits)
     }
+
+    // MARK: - Structure
 
     private func applyStructure(text: String, mode: StructureMode) -> (text: String, edits: [TranscriptEdit]) {
         switch mode {
@@ -178,7 +206,8 @@ public struct RuleBasedCleanupEngine: CleanupEngine, Sendable {
     }
 
     private func collapseWhitespace(_ text: String) -> String {
-        let collapsed = text.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        let range = NSRange(text.startIndex..., in: text)
+        let collapsed = Self.whitespaceRegex.stringByReplacingMatches(in: text, range: range, withTemplate: " ")
         return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/StenoKit/Sources/StenoKit/Services/SnippetService.swift
+++ b/StenoKit/Sources/StenoKit/Services/SnippetService.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public actor SnippetService {
     private var snippets: [Snippet]
+    /// Compiled regexes keyed by lowercased trigger. Invalidated on mutation.
+    private var regexCache: [String: NSRegularExpression] = [:]
 
     public init(snippets: [Snippet] = []) {
         self.snippets = snippets
@@ -13,10 +15,12 @@ public actor SnippetService {
         } else {
             snippets.append(snippet)
         }
+        regexCache.removeAll()
     }
 
     public func remove(id: UUID) {
         snippets.removeAll { $0.id == id }
+        regexCache.removeAll()
     }
 
     public func list() -> [Snippet] {
@@ -42,14 +46,22 @@ public actor SnippetService {
     }
 
     private func expand(_ snippet: Snippet, in text: String) -> String {
-        let escaped = NSRegularExpression.escapedPattern(for: snippet.trigger)
-        let pattern = "\\b\(escaped)\\b"
-
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
-            return text
+        let cacheKey = snippet.trigger.lowercased()
+        let regex: NSRegularExpression
+        if let cached = regexCache[cacheKey] {
+            regex = cached
+        } else {
+            let escaped = NSRegularExpression.escapedPattern(for: snippet.trigger)
+            let pattern = "\\b\(escaped)\\b"
+            guard let compiled = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+                return text
+            }
+            regexCache[cacheKey] = compiled
+            regex = compiled
         }
 
         let range = NSRange(text.startIndex..., in: text)
-        return regex.stringByReplacingMatches(in: text, range: range, withTemplate: snippet.expansion)
+        let safeExpansion = NSRegularExpression.escapedTemplate(for: snippet.expansion)
+        return regex.stringByReplacingMatches(in: text, range: range, withTemplate: safeExpansion)
     }
 }

--- a/StenoKit/Sources/StenoKit/Services/WhisperCLITranscriptionEngine.swift
+++ b/StenoKit/Sources/StenoKit/Services/WhisperCLITranscriptionEngine.swift
@@ -35,9 +35,12 @@ public struct WhisperCLITranscriptionEngine: TranscriptionEngine, Sendable {
     }
 
     private let config: Configuration
+    /// Cached at init to avoid copying ProcessInfo.environment + stat() calls per transcription.
+    private let cachedEnvironment: [String: String]
 
     public init(config: Configuration) {
         self.config = config
+        self.cachedEnvironment = Self.buildProcessEnvironment(config: config)
     }
 
     public func transcribe(audioURL: URL, languageHints: [String]) async throws -> RawTranscript {
@@ -69,7 +72,7 @@ public struct WhisperCLITranscriptionEngine: TranscriptionEngine, Sendable {
         let result = try await ProcessRunner.run(
             executableURL: config.whisperCLIPath,
             arguments: args,
-            environment: processEnvironment(),
+            environment: cachedEnvironment,
             standardOutput: FileHandle.nullDevice
         )
 
@@ -102,7 +105,7 @@ public struct WhisperCLITranscriptionEngine: TranscriptionEngine, Sendable {
         return lower.isEmpty ? nil : lower
     }
 
-    private func processEnvironment() -> [String: String] {
+    private static func buildProcessEnvironment(config: Configuration) -> [String: String] {
         var env = ProcessInfo.processInfo.environment
 
         // Local whisper.cpp builds commonly rely on DYLD_* paths.
@@ -113,7 +116,7 @@ public struct WhisperCLITranscriptionEngine: TranscriptionEngine, Sendable {
             return env
         }
 
-        let libSearchPaths = dynamicLibrarySearchPaths()
+        let libSearchPaths = dynamicLibrarySearchPaths(config: config)
         guard !libSearchPaths.isEmpty else {
             return env
         }
@@ -133,7 +136,7 @@ public struct WhisperCLITranscriptionEngine: TranscriptionEngine, Sendable {
         return env
     }
 
-    private func dynamicLibrarySearchPaths() -> [String] {
+    private static func dynamicLibrarySearchPaths(config: Configuration) -> [String] {
         let fileManager = FileManager.default
         let binDir = config.whisperCLIPath.deletingLastPathComponent()
         let buildDir = binDir.deletingLastPathComponent()
@@ -148,7 +151,7 @@ public struct WhisperCLITranscriptionEngine: TranscriptionEngine, Sendable {
         return orderedUnique(candidates.filter { fileManager.fileExists(atPath: $0) })
     }
 
-    private func orderedUnique(_ values: [String]) -> [String] {
+    private static func orderedUnique(_ values: [String]) -> [String] {
         var seen: Set<String> = []
         var output: [String] = []
         output.reserveCapacity(values.count)

--- a/StenoKit/Sources/StenoKit/Utilities/ProcessRunner.swift
+++ b/StenoKit/Sources/StenoKit/Utilities/ProcessRunner.swift
@@ -33,15 +33,49 @@ public enum ProcessRunner {
         process.standardOutput = standardOutput ?? outputPipe
         process.standardError = standardError ?? errorPipe
 
+        // Stream pipe data as it arrives to prevent the subprocess from blocking
+        // on a full pipe buffer (64 KB on macOS). Without streaming, a verbose
+        // subprocess can deadlock: it blocks on write(), we wait for it to exit.
+        let outputBuffer = PipeAccumulator()
+        let errorBuffer = PipeAccumulator()
+
+        if let pipe = outputPipe {
+            pipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                if !chunk.isEmpty { outputBuffer.append(chunk) }
+            }
+        }
+        if let pipe = errorPipe {
+            pipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                if !chunk.isEmpty { errorBuffer.append(chunk) }
+            }
+        }
+
         let state = ProcessRunState(process: process)
 
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ProcessExecutionResult, Error>) in
                 state.prepare(continuation: continuation)
                 process.terminationHandler = { _ in
-                    let output = outputPipe?.fileHandleForReading.readDataToEndOfFile() ?? Data()
-                    let error = errorPipe?.fileHandleForReading.readDataToEndOfFile() ?? Data()
-                    state.finish(terminationStatus: process.terminationStatus, standardOutput: output, standardError: error)
+                    // Disable streaming handlers first, then drain remaining bytes.
+                    outputPipe?.fileHandleForReading.readabilityHandler = nil
+                    errorPipe?.fileHandleForReading.readabilityHandler = nil
+
+                    if let pipe = outputPipe {
+                        let remaining = pipe.fileHandleForReading.readDataToEndOfFile()
+                        if !remaining.isEmpty { outputBuffer.append(remaining) }
+                    }
+                    if let pipe = errorPipe {
+                        let remaining = pipe.fileHandleForReading.readDataToEndOfFile()
+                        if !remaining.isEmpty { errorBuffer.append(remaining) }
+                    }
+
+                    state.finish(
+                        terminationStatus: process.terminationStatus,
+                        standardOutput: outputBuffer.consume(),
+                        standardError: errorBuffer.consume()
+                    )
                 }
 
                 do {
@@ -53,6 +87,25 @@ public enum ProcessRunner {
         } onCancel: {
             state.cancel()
         }
+    }
+}
+
+/// Thread-safe accumulator for pipe data arriving via readabilityHandler.
+private final class PipeAccumulator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    func consume() -> Data {
+        lock.lock()
+        let result = data
+        lock.unlock()
+        return result
     }
 }
 
@@ -125,7 +178,17 @@ private final class ProcessRunState: @unchecked Sendable {
         lock.unlock()
 
         if process.isRunning {
-            process.terminate()
+            process.terminate() // SIGTERM
+            // Escalate to SIGKILL after 3 seconds if the subprocess ignores SIGTERM.
+            let pid = process.processIdentifier
+            DispatchQueue.global().asyncAfter(deadline: .now() + 3) { [self] in
+                guard pid > 0,
+                      self.process.isRunning,
+                      self.process.processIdentifier == pid else {
+                    return
+                }
+                kill(pid, SIGKILL)
+            }
         } else if let continuation {
             // Resume outside lock. See withTaskCancellationHandler lock guidance.
             continuation.resume(throwing: CancellationError())

--- a/StenoKit/Tests/StenoKitTests/MacMediaInterruptionServiceTests.swift
+++ b/StenoKit/Tests/StenoKitTests/MacMediaInterruptionServiceTests.swift
@@ -109,6 +109,24 @@ func mediaInterruptionPausesWhenPlaybackIsActive() async {
     #expect(recorder.sendCalls == 1)
 }
 
+@Test("Media key tap location defaults to HID")
+func mediaKeyTapLocationDefaultsToHID() {
+    let tap = stenoMediaKeyTapLocation(environment: [:])
+    #expect(tap == .cghidEventTap)
+}
+
+@Test("Media key tap location honors annotated override")
+func mediaKeyTapLocationHonorsAnnotatedOverride() {
+    let tap = stenoMediaKeyTapLocation(environment: ["STENO_MEDIA_KEY_TAP": "annotated"])
+    #expect(tap == .cgAnnotatedSessionEventTap)
+}
+
+@Test("Media key tap location falls back to HID for invalid overrides")
+func mediaKeyTapLocationFallsBackToHIDForInvalidOverride() {
+    let tap = stenoMediaKeyTapLocation(environment: ["STENO_MEDIA_KEY_TAP": "nope"])
+    #expect(tap == .cghidEventTap)
+}
+
 @MainActor
 @Test("Media interruption pauses when playback is likely active")
 func mediaInterruptionPausesWhenPlaybackIsLikelyActive() async {

--- a/StenoKit/Tests/StenoKitTests/WhisperCLITranscriptionEngineTests.swift
+++ b/StenoKit/Tests/StenoKitTests/WhisperCLITranscriptionEngineTests.swift
@@ -107,23 +107,15 @@ func whisperCLITranscriptionEngineMissingOutput() async throws {
     }
 }
 
-@Test("WhisperCLITranscriptionEngine is cancellable")
-func whisperCLITranscriptionEngineCancellation() async throws {
+@Test("WhisperCLITranscriptionEngine cancellation escalates when child ignores SIGTERM")
+func whisperCLITranscriptionEngineCancellationEscalation() async throws {
     let scriptURL = try makeExecutableScript(
         """
         #!/bin/sh
-        sleep 5
-        output_base=""
-        while [ "$#" -gt 0 ]; do
-          if [ "$1" = "-of" ]; then
-            shift
-            output_base="$1"
-          fi
-          shift
+        trap '' TERM
+        while :; do
+          sleep 1
         done
-        if [ -n "$output_base" ]; then
-          printf "late output\\n" > "${output_base}.txt"
-        fi
         """
     )
     defer { try? FileManager.default.removeItem(at: scriptURL) }
@@ -146,14 +138,41 @@ func whisperCLITranscriptionEngineCancellation() async throws {
 
     try await Task.sleep(nanoseconds: 120_000_000)
     task.cancel()
+    let cancellationStart = Date()
 
     do {
-        _ = try await task.value
+        _ = try await awaitTaskValue(task, timeoutNanoseconds: 6_000_000_000)
         Issue.record("Expected cancellation to throw.")
     } catch is CancellationError {
-        // Expected.
+        let elapsed = Date().timeIntervalSince(cancellationStart)
+        #expect(elapsed < 6.0)
+    } catch is TaskValueTimeoutError {
+        Issue.record("Cancellation did not complete within timeout.")
     } catch {
         Issue.record("Expected CancellationError, got: \(error)")
+    }
+}
+
+private struct TaskValueTimeoutError: Error {}
+
+private func awaitTaskValue<T>(
+    _ task: Task<T, Error>,
+    timeoutNanoseconds: UInt64
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await task.value
+        }
+        group.addTask {
+            try await Task.sleep(nanoseconds: timeoutNanoseconds)
+            task.cancel()
+            throw TaskValueTimeoutError()
+        }
+        guard let value = try await group.next() else {
+            throw TaskValueTimeoutError()
+        }
+        group.cancelAll()
+        return value
     }
 }
 


### PR DESCRIPTION
## Summary

This PR prepares the `v0.1.7` patch release with stability and performance hardening across hotkey lifecycle, media interruption routing, process cancellation, and cleanup-path efficiency.

## What changed

- Hardened hotkey lifecycle and shutdown safety:
  - Async-gated press-to-talk callbacks
  - Tap re-enable debounce
  - Idempotent app teardown and overlay prewarm
  - Defensive overlay/hotkey cleanup paths
- Isolated synthetic event routing:
  - Insertion/paste use configurable synthetic tap policy
  - Media keys use dedicated HID-default tap resolver (`STENO_MEDIA_KEY_TAP`)
  - Media bridge deinit teardown no longer synchronously blocks callback queue
- Hardened process execution:
  - Streaming pipe reads via readability handlers
  - PID-safe cancellation escalation to `SIGKILL`
  - Cached whisper process environment setup
- Improved cleanup performance:
  - Precompiled filler and structure regex use
  - Lexicon/snippet regex caching with invalidation
  - Longest-first lexicon ordering invariant
- Reduced history persistence overhead by removing pretty-printed JSON writes

## Tests

- Added media key tap routing regression coverage:
  - HID default
  - annotated override
  - invalid override fallback
- Added cancellation regression coverage for child processes that ignore `SIGTERM`

## Validation run

- `xcodegen generate`
- `swift test --package-path StenoKit` ✅ (66 tests)
- `xcodebuild build -project Steno.xcodeproj -scheme Steno -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` ✅
- `swift run --package-path StenoKit StenoBenchmarkCLI run-all --manifest research/benchmarks/manifest.json --raw-output research/benchmarks/results/raw_engine.json --pipeline-output research/benchmarks/results/steno_pipeline.json --mac-sanity research/benchmarks/results/mac_sanity.json --report-output research/benchmarks/REPORT.md --whisper-cli vendor/whisper.cpp/build/bin/whisper-cli --model vendor/whisper.cpp/models/ggml-small.en.bin --threads 8 --default-language en --lexicon research/benchmarks/lexicon.json` ✅
- `swift run --package-path StenoKit StenoBenchmarkCLI validate-report --report research/benchmarks/REPORT.md` ✅
- `swift run --package-path StenoKit StenoBenchmarkCLI validate-pipeline --pipeline research/benchmarks/results/steno_pipeline.json --max-wer-delta 0 --max-cer-delta 0 --max-regressed-samples 0` ✅
